### PR TITLE
Collapsable volunteer & clinic manager information

### DIFF
--- a/src/components/CollapsibleInfoSection.js
+++ b/src/components/CollapsibleInfoSection.js
@@ -1,18 +1,19 @@
 import React, { useState } from 'react'
 
 const InfoSection = ({ sectionInfo }) => {
-  const [showHide, setShowHide] = useState('none')
+  const [collapsed, setCollapsed] = useState(true)
 
   const handleClick = () => {
-    showHide === 'none' ? setShowHide('block') : setShowHide('none')
-    console.log(showHide)
+    collapsed === true ? setCollapsed(false) : setCollapsed(true)
   }
 
   return (
     <section onClick={() => handleClick()} className='section volunteerInfo'>
       <div className='container'>
-        <h2 className='volunteerInfo-title'>{sectionInfo.title}</h2>
-        <div style={{ display: showHide }}>
+        <h2 className={`volunteerInfo${collapsed ? '' : '-title'}`}>
+          {sectionInfo.title}
+        </h2>
+        <div className={`collapsible ${collapsed ? '' : 'expand'}`}>
           {sectionInfo.description}
           {!!sectionInfo.link && (
             <div>

--- a/src/components/CollapsibleInfoSection.js
+++ b/src/components/CollapsibleInfoSection.js
@@ -3,16 +3,14 @@ import React, { useState } from 'react'
 const InfoSection = ({ sectionInfo }) => {
   const [collapsed, setCollapsed] = useState(true)
 
-  const handleClick = () => {
-    collapsed === true ? setCollapsed(false) : setCollapsed(true)
-  }
-
   return (
-    <section onClick={() => handleClick()} className='section volunteerInfo'>
+    <section
+      onMouseEnter={() => setCollapsed(false)}
+      onMouseLeave={() => setCollapsed(true)}
+      className='section volunteerInfo'
+    >
       <div className='container'>
-        <h2 className={`volunteerInfo${collapsed ? '' : '-title'}`}>
-          {sectionInfo.title}
-        </h2>
+        <h2 className='volunteerInfo-title'>{sectionInfo.title}</h2>
         <div className={`collapsible ${collapsed ? '' : 'expand'}`}>
           {sectionInfo.description}
           {!!sectionInfo.link && (

--- a/src/components/InfoSection.js
+++ b/src/components/InfoSection.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+
+const InfoSection = ({ sectionInfo }) => {
+  const [showHide, setShowHide] = useState('none')
+
+  const handleClick = () => {
+    showHide === 'none' ? setShowHide('block') : setShowHide('none')
+    console.log(showHide)
+  }
+
+  return (
+    <section onClick={() => handleClick()} className='section volunteerInfo'>
+      <div className='container'>
+        <h2 className='volunteerInfo-title'>{sectionInfo.title}</h2>
+        <div style={{ display: showHide }}>
+          {sectionInfo.description}
+          {!!sectionInfo.link && (
+            <div>
+              <a href={sectionInfo.link.url}>
+                <button className='volunteerInfo-link'>
+                  {sectionInfo.link.title}
+                </button>
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default InfoSection

--- a/src/styles/volunteer-page.scss
+++ b/src/styles/volunteer-page.scss
@@ -112,3 +112,16 @@
     }
   }
 }
+.collapsible {
+  opacity: 0;
+  height: 0;
+  overflow: hidden;
+  -webkit-transition: all 0.5s ease;
+  -moz-transition: all 0.5s ease;
+  transition: all 0.5s linear;
+}
+
+.expand {
+  opacity: 1;
+  height: auto;
+}

--- a/src/styles/volunteer-page.scss
+++ b/src/styles/volunteer-page.scss
@@ -74,6 +74,10 @@
     }
   }
 
+  &-title:hover {
+    text-decoration: underline;
+  }
+
   &-list {
     display: flex;
     flex-wrap: wrap;

--- a/src/styles/volunteer-page.scss
+++ b/src/styles/volunteer-page.scss
@@ -118,7 +118,7 @@
   overflow: hidden;
   -webkit-transition: all 0.5s ease;
   -moz-transition: all 0.5s ease;
-  transition: all 0.5s linear;
+  transition: all 0.5s ease;
 }
 
 .expand {

--- a/src/templates/clinic-man-page.js
+++ b/src/templates/clinic-man-page.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby'
 import Helmet from 'react-helmet'
 
 import Layout from '../components/Layout'
-import InfoSection from '../components/InfoSection'
+import CollapsibleInfoSection from '../components/CollapsibleInfoSection'
 import '../styles/volunteer-page.scss'
 
 export const ClinicManPageTemplate = (props) => {
@@ -12,7 +12,7 @@ export const ClinicManPageTemplate = (props) => {
 
   const mapInfo = (info) => {
     return Object.keys(info).map((key) => {
-      return <InfoSection sectionInfo={info[key]} />
+      return <CollapsibleInfoSection sectionInfo={info[key]} />
     })
   }
 

--- a/src/templates/clinic-man-page.js
+++ b/src/templates/clinic-man-page.js
@@ -4,6 +4,7 @@ import { graphql } from 'gatsby'
 import Helmet from 'react-helmet'
 
 import Layout from '../components/Layout'
+import InfoSection from '../components/InfoSection'
 import '../styles/volunteer-page.scss'
 
 export const ClinicManPageTemplate = (props) => {
@@ -11,14 +12,7 @@ export const ClinicManPageTemplate = (props) => {
 
   const mapInfo = (info) => {
     return Object.keys(info).map((key) => {
-      return (
-        <section className='section volunteerInfo'>
-          <div className='container'>
-            <h2 className='volunteerInfo-title'>{info[key].title}</h2>
-            <div>{info[key].description}</div>
-          </div>
-        </section>
-      )
+      return <InfoSection sectionInfo={info[key]} />
     })
   }
 

--- a/src/templates/volunteer-page.js
+++ b/src/templates/volunteer-page.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby'
 import Helmet from 'react-helmet'
 
 import Layout from '../components/Layout'
-import InfoSection from '../components/InfoSection'
+import CollapsibleInfoSection from '../components/CollapsibleInfoSection'
 import '../styles/volunteer-page.scss'
 
 export const VolunteerPageTemplate = (props) => {
@@ -12,7 +12,7 @@ export const VolunteerPageTemplate = (props) => {
 
   const mapInfo = (info) => {
     return Object.keys(info).map((key) => {
-      return <InfoSection sectionInfo={info[key]} />
+      return <CollapsibleInfoSection sectionInfo={info[key]} />
     })
   }
 

--- a/src/templates/volunteer-page.js
+++ b/src/templates/volunteer-page.js
@@ -4,6 +4,7 @@ import { graphql } from 'gatsby'
 import Helmet from 'react-helmet'
 
 import Layout from '../components/Layout'
+import InfoSection from '../components/InfoSection'
 import '../styles/volunteer-page.scss'
 
 export const VolunteerPageTemplate = (props) => {
@@ -11,21 +12,7 @@ export const VolunteerPageTemplate = (props) => {
 
   const mapInfo = (info) => {
     return Object.keys(info).map((key) => {
-      return (
-        <section className='section volunteerInfo'>
-          <div className='container'>
-            <h2 className='volunteerInfo-title'>{info[key].title}</h2>
-            <div>{info[key].description}</div>
-            {!!info[key].link && (
-              <a href={info[key].link.url}>
-                <button className='volunteerInfo-link'>
-                  {info[key].link.title}
-                </button>
-              </a>
-            )}
-          </div>
-        </section>
-      )
+      return <InfoSection sectionInfo={info[key]} />
     })
   }
 


### PR DESCRIPTION
Updates volunteer & clinic manager information to be collapsed on default and expand when moused over. 

I'm not sure if this is something we want to merge in right now or wait until design comes back with suggestions. Although going through this exercise it reminded me that we might want to discuss using a styling framework like material ui, bootstrap, etc. It would make these kinda changes easier and make everyone's work more uniform. Just a thought. 