### PR TITLE
1x6 instead of 2x3 for profile fix

### DIFF
--- a/src/Subpages/Resources/AssistanceEducation.jsx
+++ b/src/Subpages/Resources/AssistanceEducation.jsx
@@ -64,7 +64,7 @@ const AssistanceEducation = () => {
                 </Typography>
               </div>
             }
-            image={<Box component="img" src={wallet} height={300} />}
+            image={<Box component="img" src={wallet} width={"100%"} />}
           />
         </Container>
       </Box>

--- a/src/Subpages/WhyVacate/IconWithHeaderAndText.jsx
+++ b/src/Subpages/WhyVacate/IconWithHeaderAndText.jsx
@@ -1,46 +1,56 @@
 import { SvgIcon } from "@material-ui/core";
 import {
-    Grid,
-    Typography,
-    ListItem,
-    ListItemIcon,
-    makeStyles
+  Grid,
+  Typography,
+  ListItem,
+  ListItemIcon,
+  makeStyles,
 } from "@material-ui/core";
 
 const useStyles = makeStyles((theme) => ({
-    mainText: {
-      minWidth: 150,
-      fontFamily: ["Roboto", "sans-serif"],
-      fontSize: 16,
-      paddingTop: 5
-    },
-    icons: {
-        color: theme.palette.highlight.main,
-        fontSize: "5rem",
-        margin: theme.spacing(3),
-      }
+  mainText: {
+    minWidth: 150,
+    fontFamily: ["Roboto", "sans-serif"],
+    fontSize: 16,
+    paddingTop: 5,
+  },
+  icons: {
+    color: theme.palette.highlight.main,
+    fontSize: "5rem",
+    margin: theme.spacing(2),
+  },
+  gridItemStyle: {
+    paddingBottom: theme.spacing(3),
+  },
 }));
 
 export const IconWithHeaderAndText = (props) => {
-    const classes = useStyles();
-    const { icon, header, text } = props;
-    const textItems = text.map((t, idx) => (
-        <Typography className={classes.mainText} key={idx} variant="body1" align="left">
-            {t}
-        </Typography>
-    ))
+  const classes = useStyles();
+  const { icon, header, text } = props;
+  const textItems = text.map((t, idx) => (
+    <Typography
+      className={classes.mainText}
+      key={idx}
+      variant="body1"
+      align="left"
+    >
+      {t}
+    </Typography>
+  ));
 
-    return (
-        <>
-            <ListItem>
-                <ListItemIcon>
-                    <SvgIcon component={icon} className={classes.icons} />
-                </ListItemIcon>
-                <Grid container alignItems="flex-start">
-                    <Typography variant="h4">{header}</Typography>
-                    { textItems }
-                </Grid>
-            </ListItem>
-        </>
-    )
-}
+  return (
+    <>
+      <Grid container justifyContent="center">
+        <Grid item>
+          <SvgIcon component={icon} className={classes.icons} />
+        </Grid>
+        <Grid className={classes.gridItemStyle} item xs={12} sm={10} md={10} lg={10} xl={10}>
+          <Grid container alignItems="flex-start">
+            <Typography variant="h4">{header}</Typography>
+            {textItems}
+          </Grid>
+        </Grid>
+      </Grid>
+    </>
+  );
+};


### PR DESCRIPTION
[1x6 instead of 2x3 for profile](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwsO84y649cTJfmn/rec8F7tIgEKqUfxoL?blocks=hide)

I refactored the root component to fix this, I checked the other places it is used, and it still looks like it is okay, but let me know if I missed a usage.