### PR TITLE
Fix Tabs Contrast

### DIFF
--- a/src/Components/TabPanelGroup.jsx
+++ b/src/Components/TabPanelGroup.jsx
@@ -21,10 +21,11 @@ const TabPanel = (props) => {
 };
 
 const useStyles = makeStyles((theme) => ({
-  root: {
+  tabPanelStyle: {
     backgroundColor: "white",
-    borderRadius: "5px",
     color: "black",
+    borderBottomRightRadius: 5,
+    borderBottomLeftRadius: 5,
   }
 }));
 
@@ -37,15 +38,15 @@ const TabPanelGroup = (props) => {
     setValue(newValue);
   };
   return (
-    <Box className={classes.root}>
-      <Tabs value={value} onChange={handleChange} centered>
+    <Box >
+      <Tabs  value={value} onChange={handleChange} variant="fullWidth">
         {tabs.map((tab) => (
-          <Tab key={tab.index} label={tab.label}/>
+          <Tab className={classes.tabStyle} key={tab.index} label={tab.label}/>
         ))}
       </Tabs>
 
       {tabs.map((tab) => (
-        <TabPanel key={tab.index} value={value} index={tab.index}>
+        <TabPanel className={classes.tabPanelStyle} key={tab.index} value={value} index={tab.index}>
           {tab.content}
         </TabPanel>
       ))}

--- a/src/Components/Theme.jsx
+++ b/src/Components/Theme.jsx
@@ -87,6 +87,26 @@ Theme.overrides = {
       backgroundColor: Theme.palette.primary.main,
       width: "250px"
     }
+  },
+  MuiTabs: {
+    root: {
+      borderTopLeftRadius: 5,
+      borderTopRightRadius: 5,
+
+    },
+    indicator: {
+      height: 0,
+    }
+  },
+  MuiTab: {
+    root: {
+      fontSize: 14,
+      backgroundColor: Theme.palette.primary.light,
+    },
+    selected: {
+      color: Theme.palette.primary.dark,
+      backgroundColor: "white",
+    }
   }
 };
 


### PR DESCRIPTION
override tabs, tab, indicator, in theme, customize tab panel to match design more closely.
[improve contrast on active tab](https://airtable.com/appfJZShN8K4tcWHU/tblvBIYoi6TLmdRAv/viwsO84y649cTJfmn/rec0yYcwecfzbN3oC?blocks=hide)