### PR TITLE
fix tooltip width for narrow devices

### DIFF
--- a/src/Components/ToolTipModal.jsx
+++ b/src/Components/ToolTipModal.jsx
@@ -8,7 +8,8 @@ const boxStyle = {
   top: "50%",
   left: "50%",
   transform: "translate(-50%, -50%)",
-  width: 400,
+  width: "90%",
+  maxWidth: "24em",
   backgroundColor: "var(--white)",
   border: "2px solid #000",
   boxShadow: 24,
@@ -50,7 +51,7 @@ const ToolTipModal = (props) => {
               rel="noreferrer"
             >
               here
-            </a>
+            </a>.
           </Typography>
         </Box>
       </Modal>


### PR DESCRIPTION
The tooltip looked bad on my iPhone SE. This PR fixes that.

Before:
<img width="379" alt="Screen Shot 2022-02-04 at 3 19 01 PM" src="https://user-images.githubusercontent.com/28968357/152615881-c3454639-a764-435b-9fbf-28568e92c1ac.png">

After:
<img width="377" alt="Screen Shot 2022-02-04 at 3 19 06 PM" src="https://user-images.githubusercontent.com/28968357/152615888-8d85baa3-87af-4411-9282-b34fe463cf59.png">

It also adds a period at the end of the sentence.

